### PR TITLE
Reworked L7 DPI integration.

### DIFF
--- a/src/plugins/upf/dpi.c
+++ b/src/plugins/upf/dpi.c
@@ -609,8 +609,9 @@ vnet_upf_app_add_del(u8 * name, u8 add)
       app->rules_by_id = hash_create_mem (0, sizeof (u32), sizeof (uword));
       app->path_db_index = ~0;
       app->host_db_index = ~0;
+      app->id = app - sm->upf_apps;
 
-      hash_set_mem (sm->upf_app_by_name, app->name, app - sm->upf_apps);
+      hash_set_mem (sm->upf_app_by_name, app->name, app->id);
     }
   else
     {

--- a/src/plugins/upf/dpi.h
+++ b/src/plugins/upf/dpi.h
@@ -127,10 +127,11 @@ upf_dpi_parse_ip4_packet(ip4_header_t * ip4, u32 path_db_id,
 }
 
 always_inline upf_pdr_t *
-upf_get_highest_dpi_pdr (struct rules * active)
+upf_get_highest_dpi_pdr (struct rules * active, int direction)
 {
   upf_pdr_t *pdr = NULL;
   upf_pdr_t *pdr_iter = NULL;
+  int iter_direction = 0;
 
   if (vec_len(active->pdr) == 0)
     return NULL;
@@ -138,6 +139,10 @@ upf_get_highest_dpi_pdr (struct rules * active)
   vec_foreach (pdr_iter, active->pdr)
     {
       if (!pdr_iter->app_name)
+        continue;
+
+      iter_direction = (pdr_iter->pdi.src_intf == SRC_INTF_ACCESS) ? UL_SDF : DL_SDF;
+      if (iter_direction != direction)
         continue;
 
       if (pdr == NULL)

--- a/src/plugins/upf/dpi.h
+++ b/src/plugins/upf/dpi.h
@@ -179,6 +179,7 @@ upf_update_flow_app_index (flow_entry_t * flow, upf_pdr_t * pdr,
                                    pdr->dpi_path_db_id,
                                    pdr->dpi_host_db_id,
                                    &flow->app_index);
+          flow->client_pdr_id = pdr->id;
         }
     }
 }

--- a/src/plugins/upf/dpi.h
+++ b/src/plugins/upf/dpi.h
@@ -160,12 +160,15 @@ upf_get_highest_dpi_pdr (struct rules * active, int direction)
 
 always_inline void
 upf_update_flow_app_index (flow_entry_t * flow, upf_pdr_t * pdr,
-                           u8 * pl, int is_ip4)
+                           u8 * pl, int is_ip4, u8 direction)
 {
   if (!flow)
     return;
 
   if (flow->app_index != ~0)
+    return;
+
+  if (flow->client_direction != direction)
     return;
 
   if (is_ip4)

--- a/src/plugins/upf/dpi.h
+++ b/src/plugins/upf/dpi.h
@@ -184,6 +184,35 @@ upf_update_flow_app_index (flow_entry_t * flow, upf_pdr_t * pdr,
     }
 }
 
+always_inline upf_pdr_t *
+upf_get_dpi_pdr_by_name (struct rules * active, int direction, u32 app_index)
+{
+  upf_pdr_t *pdr = NULL;
+  upf_pdr_t *pdr_iter = NULL;
+  int iter_direction = 0;
+
+  if (vec_len(active->pdr) == 0)
+    return NULL;
+
+  vec_foreach (pdr_iter, active->pdr)
+    {
+      if (!pdr_iter->app_name)
+        continue;
+
+      iter_direction = (pdr_iter->pdi.src_intf == SRC_INTF_ACCESS) ? UL_SDF : DL_SDF;
+      if (iter_direction != direction)
+        continue;
+
+      if (pdr->app_index == app_index)
+        {
+          pdr = pdr_iter;
+          break;
+        }
+    }
+
+  return pdr;
+}
+
 #endif /* __included_upf_dpi_h__ */
 
 /*

--- a/src/plugins/upf/dpi.h
+++ b/src/plugins/upf/dpi.h
@@ -188,29 +188,29 @@ always_inline upf_pdr_t *
 upf_get_dpi_pdr_by_name (struct rules * active, int direction, u32 app_index)
 {
   upf_pdr_t *pdr = NULL;
-  upf_pdr_t *pdr_iter = NULL;
+  upf_pdr_t *res = NULL;
   int iter_direction = 0;
 
   if (vec_len(active->pdr) == 0)
     return NULL;
 
-  vec_foreach (pdr_iter, active->pdr)
+  vec_foreach (pdr, active->pdr)
     {
-      if (!pdr_iter->app_name)
+      if (!pdr->app_name)
         continue;
 
-      iter_direction = (pdr_iter->pdi.src_intf == SRC_INTF_ACCESS) ? UL_SDF : DL_SDF;
+      iter_direction = (pdr->pdi.src_intf == SRC_INTF_ACCESS) ? UL_SDF : DL_SDF;
       if (iter_direction != direction)
         continue;
 
       if (pdr->app_index == app_index)
         {
-          pdr = pdr_iter;
+          res = pdr;
           break;
         }
     }
 
-  return pdr;
+  return res;
 }
 
 #endif /* __included_upf_dpi_h__ */

--- a/src/plugins/upf/flowtable.h
+++ b/src/plugins/upf/flowtable.h
@@ -126,6 +126,9 @@ typedef struct flow_entry {
 
     /* L7 app index */
     u32 app_index;
+
+    /* TCP client direction */
+    u8 client_direction;
 } flow_entry_t;
 
 /* Timers (in seconds) */

--- a/src/plugins/upf/flowtable.h
+++ b/src/plugins/upf/flowtable.h
@@ -129,6 +129,9 @@ typedef struct flow_entry {
 
     /* TCP client direction */
     u8 client_direction;
+
+    /* Client PDR */
+    u32 client_pdr_id;
 } flow_entry_t;
 
 /* Timers (in seconds) */

--- a/src/plugins/upf/flowtable.h
+++ b/src/plugins/upf/flowtable.h
@@ -132,6 +132,9 @@ typedef struct flow_entry {
 
     /* Client PDR */
     u32 client_pdr_id;
+
+    /* Server PDR */
+    u32 server_pdr_id;
 } flow_entry_t;
 
 /* Timers (in seconds) */

--- a/src/plugins/upf/flowtable_impl.h
+++ b/src/plugins/upf/flowtable_impl.h
@@ -588,6 +588,11 @@ flowtable_get_flow(u8 * packet, flowtable_per_session_t * fmt,
       return -1;
     }
 
+  if (created == 1)
+    {
+      (*flow)->client_direction = direction;
+    }
+
   /* timer management */
   if (flow_update_lifetime(*flow, packet, is_ip4))
     {

--- a/src/plugins/upf/flowtable_impl.h
+++ b/src/plugins/upf/flowtable_impl.h
@@ -437,8 +437,11 @@ flowtable_entry_lookup_create(flowtable_main_t * fm,
     f->lifetime = TIMER_DEFAULT_LIFETIME;
     f->expire = now + TIMER_DEFAULT_LIFETIME;
 
-    /* init app id */
+    /* init UPF fields */
     f->app_index = ~0;
+    f->client_direction = ~0;
+    f->client_pdr_id = ~0;
+    f->server_pdr_id = ~0;
 
     /* update stats */
     f->stats[direction].pkts++;

--- a/src/plugins/upf/upf.h
+++ b/src/plugins/upf/upf.h
@@ -263,6 +263,7 @@ typedef struct {
   u16 far_id;
   u16 *urr_ids;
   u8 *app_name;
+  u32 app_index;
   u32 dpi_path_db_id;
   u32 dpi_host_db_id;
 } upf_pdr_t;
@@ -511,6 +512,7 @@ typedef struct {
 } upf_dpi_rule_t;
 
 typedef struct {
+  u32 id;
   u8 * name;
   /* Rules hash */
   uword* rules_by_id;

--- a/src/plugins/upf/upf_classify.c
+++ b/src/plugins/upf/upf_classify.c
@@ -257,9 +257,6 @@ upf_classify (vlib_main_t * vm, vlib_node_runtime_t * node,
 		  far = sx_get_far_by_id(active, pdr->far_id);
 
 		  upf_update_flow_app_index(flow, pdr, pl, is_ip4);
-		  gtp_debug("PDR %u, FAR %u, flow app: %v, path DPI DB id %u\n",
-		            pdr->id, pdr->far_id, flow->app_index,
-		            pdr->dpi_path_db_id);
 
 	      /* Outer Header Removal */
 	      switch (pdr->outer_header_removal)

--- a/src/plugins/upf/upf_classify.c
+++ b/src/plugins/upf/upf_classify.c
@@ -157,6 +157,12 @@ upf_classify (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  acl = is_ip4 ? active->sdf[direction].ip4 : active->sdf[direction].ip6;
 	  dpi_pdr = upf_get_highest_dpi_pdr(active, direction);
 
+	  if (flow && (flow->client_direction == direction) && flow->app_index != ~0)
+	    {
+	      pdr = sx_get_pdr_by_id(active, flow->client_pdr_id);
+	    }
+	  else
+	    {
 	  if (acl == NULL)
 	    {
 	      gtpu_intf_tunnel_key_t key;
@@ -250,6 +256,7 @@ upf_classify (vlib_main_t * vm, vlib_node_runtime_t * node,
 		          pdr = dpi_pdr;
 		        }
 		    }
+		}
 		}
 
 	  if (PREDICT_TRUE (pdr != 0))

--- a/src/plugins/upf/upf_classify.c
+++ b/src/plugins/upf/upf_classify.c
@@ -256,7 +256,7 @@ upf_classify (vlib_main_t * vm, vlib_node_runtime_t * node,
 		{
 		  far = sx_get_far_by_id(active, pdr->far_id);
 
-		  upf_update_flow_app_index(flow, pdr, pl, is_ip4);
+		  upf_update_flow_app_index(flow, pdr, pl, is_ip4, direction);
 
 	      /* Outer Header Removal */
 	      switch (pdr->outer_header_removal)

--- a/src/plugins/upf/upf_classify.c
+++ b/src/plugins/upf/upf_classify.c
@@ -161,6 +161,18 @@ upf_classify (vlib_main_t * vm, vlib_node_runtime_t * node,
 	    {
 	      pdr = sx_get_pdr_by_id(active, flow->client_pdr_id);
 	    }
+	  else if (flow && (flow->client_direction != direction) && flow->app_index != ~0)
+	    {
+	      if (flow->server_pdr_id != ~0)
+		{
+		  pdr = sx_get_pdr_by_id(active, flow->server_pdr_id);
+		}
+	      else
+		{
+		  pdr = upf_get_dpi_pdr_by_name(active, !direction, flow->app_index);
+		  flow->server_pdr_id = pdr->id;
+		}
+	    }
 	  else
 	    {
 	  if (acl == NULL)


### PR DESCRIPTION
When using this for DPI the following rules apply:

for HTTP scanning, URL and path scanning is applied only on packets originating from the client. 
The client is the side that initiated the TCP/UDP connection (i.e. send the first packet)

packets sent before DPI scanning can take place (e.g. SYN and SYN+ACK), might have been matched by ACL rules before, a flow that might have been created from that match should not preempt DPI scanning

a flow that has successfully been matched by an Application Rule, should bypass any further ACL and DPI scanning (but be aware that this is depending on the direction of the packet, PDR/PDI/FAR selection is direction dependent!!!!)

Server to Client response packets are not run through the DPI scanning, instead the following logic applies:

1. if a PDR in that direction has been chosen previously, that PDR is used, if not continue with 
2. if they belong to a flow that has been matched by a Application Rule, the matched Application Id is used to find all applicable PDRs/PDIs (correct direction, TEID and Application Id), from that list the one with the highest precedence is chosen and remembered for any future packet. If the list is empty continue with 
3. if they match a ACL PDR, that PDR is applied
4. if none of the above applied, drop the packet